### PR TITLE
Fix grid layout gaps

### DIFF
--- a/lib/CssGrid/CssGrid.ts
+++ b/lib/CssGrid/CssGrid.ts
@@ -28,6 +28,8 @@ export class CssGrid {
     cells: GridCell[]
     rowSizes: number[]
     columnSizes: number[]
+    rowGap: number
+    columnGap: number
   } {
     return CssGrid_layout(this)
   }

--- a/lib/CssGrid/CssGrid_visualize.ts
+++ b/lib/CssGrid/CssGrid_visualize.ts
@@ -15,7 +15,7 @@ export const CssGrid_visualize = (grid: CssGrid): GraphicsObject => {
     texts: [],
   }
 
-  const { cells, rowSizes, columnSizes } = layout
+  const { cells, rowSizes, columnSizes, rowGap = 0, columnGap = 0 } = layout
 
   for (const cell of cells) {
     const { column, row, columnSpan, rowSpan, key } = cell
@@ -25,10 +25,12 @@ export const CssGrid_visualize = (grid: CssGrid): GraphicsObject => {
 
     for (let i = 0; i < column; i++) {
       x += columnSizes[i]!
+      x += columnGap
     }
 
     for (let i = 0; i < row; i++) {
       y += rowSizes[i]!
+      y += rowGap
     }
 
     let width = 0
@@ -36,10 +38,12 @@ export const CssGrid_visualize = (grid: CssGrid): GraphicsObject => {
 
     for (let i = column; i < column + columnSpan; i++) {
       width += columnSizes[i]!
+      if (i < column + columnSpan - 1) width += columnGap
     }
 
     for (let i = row; i < row + rowSpan; i++) {
       height += rowSizes[i]!
+      if (i < row + rowSpan - 1) height += rowGap
     }
 
     go.rects.push({

--- a/tests/__snapshots__/level05.snap.svg
+++ b/tests/__snapshots__/level05.snap.svg
@@ -25,16 +25,16 @@
     <circle data-type="point" data-label="corner" data-x="300" data-y="100" cx="351.1111111111111" cy="292.25925925925924" r="3" fill="black" />
   </g>
   <g>
-    <rect data-type="rect" data-label="box1" data-x="60" data-y="60" x="40" y="188.55555555555557" width="124.44444444444446" height="124.44444444444443" fill="hsl(0deg, 100%, 50%)" stroke="black" stroke-width="0.9642857142857143" />
+    <rect data-type="rect" data-label="box1" data-x="55" data-y="55" x="40" y="188.55555555555557" width="114.07407407407408" height="114.07407407407405" fill="hsl(0deg, 100%, 50%)" stroke="black" stroke-width="0.9642857142857143" />
   </g>
   <g>
-    <rect data-type="rect" data-label="box2" data-x="180" data-y="60" x="164.44444444444446" y="188.55555555555557" width="124.44444444444446" height="124.44444444444443" fill="hsl(40deg, 100%, 50%)" stroke="black" stroke-width="0.9642857142857143" />
+    <rect data-type="rect" data-label="box2" data-x="185" data-y="55" x="174.8148148148148" y="188.55555555555557" width="114.0740740740741" height="114.07407407407405" fill="hsl(40deg, 100%, 50%)" stroke="black" stroke-width="0.9642857142857143" />
   </g>
   <g>
-    <rect data-type="rect" data-label="box3" data-x="60" data-y="180" x="40" y="313" width="124.44444444444446" height="124.44444444444446" fill="hsl(80deg, 100%, 50%)" stroke="black" stroke-width="0.9642857142857143" />
+    <rect data-type="rect" data-label="box3" data-x="55" data-y="185" x="40" y="323.3703703703704" width="114.07407407407408" height="114.07407407407408" fill="hsl(80deg, 100%, 50%)" stroke="black" stroke-width="0.9642857142857143" />
   </g>
   <g>
-    <rect data-type="rect" data-label="box4" data-x="180" data-y="180" x="164.44444444444446" y="313" width="124.44444444444446" height="124.44444444444446" fill="hsl(120deg, 100%, 50%)" stroke="black" stroke-width="0.9642857142857143" />
+    <rect data-type="rect" data-label="box4" data-x="185" data-y="185" x="174.8148148148148" y="323.3703703703704" width="114.0740740740741" height="114.07407407407408" fill="hsl(120deg, 100%, 50%)" stroke="black" stroke-width="0.9642857142857143" />
   </g>
   <g>
     <rect data-type="rect" data-label="box1" data-x="355" data-y="55" x="351.1111111111111" y="188.55555555555557" width="114.07407407407408" height="114.07407407407405" fill="hsl(0deg, 100%, 50%)" stroke="black" stroke-width="0.9642857142857143" />

--- a/tests/__snapshots__/level06.snap.svg
+++ b/tests/__snapshots__/level06.snap.svg
@@ -25,22 +25,22 @@
     <circle data-type="point" data-label="corner" data-x="375" data-y="100" cx="351.1111111111111" cy="313" r="3" fill="black" />
   </g>
   <g>
-    <rect data-type="rect" data-label="a" data-x="50" data-y="50" x="40" y="230.03703703703704" width="82.96296296296296" height="82.96296296296296" fill="hsl(280deg, 100%, 50%)" stroke="black" stroke-width="1.2053571428571428" />
+    <rect data-type="rect" data-label="a" data-x="40" data-y="47.5" x="40" y="230.03703703703704" width="66.37037037037037" height="78.81481481481481" fill="hsl(280deg, 100%, 50%)" stroke="black" stroke-width="1.2053571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="b" data-x="150" data-y="50" x="122.96296296296296" y="230.03703703703704" width="82.96296296296296" height="82.96296296296296" fill="hsl(320deg, 100%, 50%)" stroke="black" stroke-width="1.2053571428571428" />
+    <rect data-type="rect" data-label="b" data-x="150" data-y="47.5" x="131.25925925925924" y="230.03703703703704" width="66.37037037037038" height="78.81481481481481" fill="hsl(320deg, 100%, 50%)" stroke="black" stroke-width="1.2053571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="c" data-x="250" data-y="50" x="205.92592592592592" y="230.03703703703704" width="82.96296296296299" height="82.96296296296296" fill="hsl(0deg, 100%, 50%)" stroke="black" stroke-width="1.2053571428571428" />
+    <rect data-type="rect" data-label="c" data-x="260" data-y="47.5" x="222.5185185185185" y="230.03703703703704" width="66.37037037037041" height="78.81481481481481" fill="hsl(0deg, 100%, 50%)" stroke="black" stroke-width="1.2053571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="d" data-x="50" data-y="150" x="40" y="313" width="82.96296296296296" height="82.96296296296293" fill="hsl(40deg, 100%, 50%)" stroke="black" stroke-width="1.2053571428571428" />
+    <rect data-type="rect" data-label="d" data-x="40" data-y="152.5" x="40" y="317.14814814814815" width="66.37037037037037" height="78.81481481481478" fill="hsl(40deg, 100%, 50%)" stroke="black" stroke-width="1.2053571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="e" data-x="150" data-y="150" x="122.96296296296296" y="313" width="82.96296296296296" height="82.96296296296293" fill="hsl(80deg, 100%, 50%)" stroke="black" stroke-width="1.2053571428571428" />
+    <rect data-type="rect" data-label="e" data-x="150" data-y="152.5" x="131.25925925925924" y="317.14814814814815" width="66.37037037037038" height="78.81481481481478" fill="hsl(80deg, 100%, 50%)" stroke="black" stroke-width="1.2053571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="f" data-x="250" data-y="150" x="205.92592592592592" y="313" width="82.96296296296299" height="82.96296296296293" fill="hsl(120deg, 100%, 50%)" stroke="black" stroke-width="1.2053571428571428" />
+    <rect data-type="rect" data-label="f" data-x="260" data-y="152.5" x="222.5185185185185" y="317.14814814814815" width="66.37037037037041" height="78.81481481481478" fill="hsl(120deg, 100%, 50%)" stroke="black" stroke-width="1.2053571428571428" />
   </g>
   <g>
     <rect data-type="rect" data-label="a" data-x="415" data-y="47.5" x="351.1111111111111" y="230.03703703703704" width="66.37037037037038" height="78.81481481481481" fill="hsl(280deg, 100%, 50%)" stroke="black" stroke-width="1.2053571428571428" />

--- a/tests/__snapshots__/level12.snap.svg
+++ b/tests/__snapshots__/level12.snap.svg
@@ -25,13 +25,13 @@
     <circle data-type="point" data-label="corner" data-x="375" data-y="100" cx="351.1111111111111" cy="354.4814814814815" r="3" fill="black" />
   </g>
   <g>
-    <rect data-type="rect" data-label="auto-width" data-x="0" data-y="0" x="40" y="271.51851851851853" width="0" height="0" fill="hsl(240deg, 100%, 50%)" stroke="black" stroke-width="1.2053571428571428" />
+    <rect data-type="rect" data-label="auto-width" data-x="50" data-y="50" x="40" y="271.51851851851853" width="82.96296296296296" height="82.96296296296299" fill="hsl(240deg, 100%, 50%)" stroke="black" stroke-width="1.2053571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="fixed-width" data-x="50" data-y="0" x="40" y="271.51851851851853" width="82.96296296296296" height="0" fill="hsl(320deg, 100%, 50%)" stroke="black" stroke-width="1.2053571428571428" />
+    <rect data-type="rect" data-label="fixed-width" data-x="150" data-y="50" x="122.96296296296296" y="271.51851851851853" width="82.96296296296296" height="82.96296296296299" fill="hsl(320deg, 100%, 50%)" stroke="black" stroke-width="1.2053571428571428" />
   </g>
   <g>
-    <rect data-type="rect" data-label="flexible" data-x="200" data-y="0" x="122.96296296296296" y="271.51851851851853" width="165.92592592592595" height="0" fill="hsl(320deg, 100%, 50%)" stroke="black" stroke-width="1.2053571428571428" />
+    <rect data-type="rect" data-label="flexible" data-x="250" data-y="50" x="205.92592592592592" y="271.51851851851853" width="82.96296296296299" height="82.96296296296299" fill="hsl(320deg, 100%, 50%)" stroke="black" stroke-width="1.2053571428571428" />
   </g>
   <g>
     <rect data-type="rect" data-label="auto-width" data-x="411.9140625" data-y="50" x="351.1111111111111" y="271.51851851851853" width="61.25" height="82.96296296296299" fill="hsl(240deg, 100%, 50%)" stroke="black" stroke-width="1.2053571428571428" />

--- a/tests/level01.test.ts
+++ b/tests/level01.test.ts
@@ -38,6 +38,7 @@ test("level01", () => {
           "rowSpan": 1,
         },
       ],
+      "columnGap": 0,
       "columnSizes": [
         20,
         20,
@@ -45,6 +46,7 @@ test("level01", () => {
         20,
         20,
       ],
+      "rowGap": 0,
       "rowSizes": [
         20,
         20,

--- a/tests/level02.test.ts
+++ b/tests/level02.test.ts
@@ -38,6 +38,7 @@ test("level02", () => {
           "rowSpan": 1,
         },
       ],
+      "columnGap": 0,
       "columnSizes": [
         20,
         20,
@@ -45,6 +46,7 @@ test("level02", () => {
         20,
         20,
       ],
+      "rowGap": 0,
       "rowSizes": [
         20,
         20,

--- a/tests/level03.test.ts
+++ b/tests/level03.test.ts
@@ -95,10 +95,12 @@ test("level03", () => {
           "rowSpan": 1,
         },
       ],
+      "columnGap": 0,
       "columnSizes": [
         100,
         100,
       ],
+      "rowGap": 0,
       "rowSizes": [
         100,
         100,

--- a/tests/level04.test.ts
+++ b/tests/level04.test.ts
@@ -95,10 +95,12 @@ test("level04", () => {
           "rowSpan": 1,
         },
       ],
+      "columnGap": 0,
       "columnSizes": [
         100,
         200,
       ],
+      "rowGap": 0,
       "rowSizes": [
         50,
         120,

--- a/tests/level05.test.ts
+++ b/tests/level05.test.ts
@@ -37,28 +37,28 @@ test("level05", () => {
   expect(laidOutResult).toMatchInlineSnapshot(`
     {
       "box1": {
-        "height": 120,
-        "width": 120,
+        "height": 110,
+        "width": 110,
         "x": 0,
         "y": 0,
       },
       "box2": {
-        "height": 120,
-        "width": 120,
-        "x": 120,
+        "height": 110,
+        "width": 110,
+        "x": 130,
         "y": 0,
       },
       "box3": {
-        "height": 120,
-        "width": 120,
+        "height": 110,
+        "width": 110,
         "x": 0,
-        "y": 120,
+        "y": 130,
       },
       "box4": {
-        "height": 120,
-        "width": 120,
-        "x": 120,
-        "y": 120,
+        "height": 110,
+        "width": 110,
+        "x": 130,
+        "y": 130,
       },
     }
   `)
@@ -95,13 +95,15 @@ test("level05", () => {
           "rowSpan": 1,
         },
       ],
+      "columnGap": 20,
       "columnSizes": [
-        120,
-        120,
+        110,
+        110,
       ],
+      "rowGap": 20,
       "rowSizes": [
-        120,
-        120,
+        110,
+        110,
       ],
     }
   `)

--- a/tests/level06.test.ts
+++ b/tests/level06.test.ts
@@ -49,40 +49,40 @@ test("level06", () => {
   expect(laidOutResult).toMatchInlineSnapshot(`
     {
       "a": {
-        "height": 100,
-        "width": 100,
+        "height": 95,
+        "width": 80,
         "x": 0,
         "y": 0,
       },
       "b": {
-        "height": 100,
-        "width": 100,
-        "x": 100,
+        "height": 95,
+        "width": 80,
+        "x": 110,
         "y": 0,
       },
       "c": {
-        "height": 100,
-        "width": 100,
-        "x": 200,
+        "height": 95,
+        "width": 80,
+        "x": 220,
         "y": 0,
       },
       "d": {
-        "height": 100,
-        "width": 100,
+        "height": 95,
+        "width": 80,
         "x": 0,
-        "y": 100,
+        "y": 105,
       },
       "e": {
-        "height": 100,
-        "width": 100,
-        "x": 100,
-        "y": 100,
+        "height": 95,
+        "width": 80,
+        "x": 110,
+        "y": 105,
       },
       "f": {
-        "height": 100,
-        "width": 100,
-        "x": 200,
-        "y": 100,
+        "height": 95,
+        "width": 80,
+        "x": 220,
+        "y": 105,
       },
     }
   `)
@@ -133,14 +133,16 @@ test("level06", () => {
           "rowSpan": 1,
         },
       ],
+      "columnGap": 30,
       "columnSizes": [
-        100,
-        100,
-        100,
+        80,
+        80,
+        80,
       ],
+      "rowGap": 10,
       "rowSizes": [
-        100,
-        100,
+        95,
+        95,
       ],
     }
   `)

--- a/tests/level07.test.ts
+++ b/tests/level07.test.ts
@@ -95,10 +95,12 @@ test("level07", () => {
           "rowSpan": 1,
         },
       ],
+      "columnGap": 0,
       "columnSizes": [
         100,
         200,
       ],
+      "rowGap": 0,
       "rowSizes": [
         50,
         200,

--- a/tests/level08.test.ts
+++ b/tests/level08.test.ts
@@ -95,11 +95,13 @@ test("level08", () => {
           "rowSpan": 1,
         },
       ],
+      "columnGap": 0,
       "columnSizes": [
         100,
         100,
         100,
       ],
+      "rowGap": 0,
       "rowSizes": [
         100,
         100,

--- a/tests/level09.test.ts
+++ b/tests/level09.test.ts
@@ -95,11 +95,13 @@ test("level09", () => {
           "rowSpan": 1,
         },
       ],
+      "columnGap": 0,
       "columnSizes": [
         100,
         100,
         100,
       ],
+      "rowGap": 0,
       "rowSizes": [
         100,
         100,

--- a/tests/level10.test.ts
+++ b/tests/level10.test.ts
@@ -95,12 +95,14 @@ test("level10", () => {
           "rowSpan": 1,
         },
       ],
+      "columnGap": 0,
       "columnSizes": [
         100,
         100,
         100,
         100,
       ],
+      "rowGap": 0,
       "rowSizes": [
         100,
       ],

--- a/tests/level11.test.ts
+++ b/tests/level11.test.ts
@@ -57,10 +57,12 @@ test("level11", () => {
           "rowSpan": 1,
         },
       ],
+      "columnGap": 0,
       "columnSizes": [
         100,
         100,
       ],
+      "rowGap": 0,
       "rowSizes": [
         100,
         100,

--- a/tests/level12.test.ts
+++ b/tests/level12.test.ts
@@ -31,21 +31,21 @@ test("level12", () => {
   expect(laidOutResult).toMatchInlineSnapshot(`
     {
       "auto-width": {
-        "height": 0,
-        "width": 0,
-        "x": 0,
-        "y": 0,
-      },
-      "fixed-width": {
-        "height": 0,
+        "height": 100,
         "width": 100,
         "x": 0,
         "y": 0,
       },
-      "flexible": {
-        "height": 0,
-        "width": 200,
+      "fixed-width": {
+        "height": 100,
+        "width": 100,
         "x": 100,
+        "y": 0,
+      },
+      "flexible": {
+        "height": 100,
+        "width": 100,
+        "x": 200,
         "y": 0,
       },
     }
@@ -76,13 +76,15 @@ test("level12", () => {
           "rowSpan": 1,
         },
       ],
+      "columnGap": 0,
       "columnSizes": [
-        0,
         100,
-        200,
+        100,
+        100,
       ],
+      "rowGap": 0,
       "rowSizes": [
-        0,
+        100,
       ],
     }
   `)

--- a/tests/level13.test.ts
+++ b/tests/level13.test.ts
@@ -76,11 +76,13 @@ test("level13", () => {
           "rowSpan": 1,
         },
       ],
+      "columnGap": 0,
       "columnSizes": [
         100,
         220,
         80,
       ],
+      "rowGap": 0,
       "rowSizes": [
         300,
       ],

--- a/tests/level14.test.ts
+++ b/tests/level14.test.ts
@@ -95,11 +95,13 @@ test("level14", () => {
           "rowSpan": 1,
         },
       ],
+      "columnGap": 0,
       "columnSizes": [
         100,
         100,
         100,
       ],
+      "rowGap": 0,
       "rowSizes": [
         100,
         100,

--- a/tests/level15.test.ts
+++ b/tests/level15.test.ts
@@ -95,10 +95,12 @@ test("level15", () => {
           "rowSpan": 1,
         },
       ],
+      "columnGap": 0,
       "columnSizes": [
         200,
         200,
       ],
+      "rowGap": 0,
       "rowSizes": [
         100,
         100,


### PR DESCRIPTION
## Summary
- support `gap` and percentage/auto track sizing in layout
- include gap metrics in visualization for correct item positioning
- update inline and SVG snapshots

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test -u`

------
https://chatgpt.com/codex/tasks/task_b_6889169928f0832eae89c0cc11169b35